### PR TITLE
Add mandatory `when` argument to `define-obsolete-function-alias`

### DIFF
--- a/magit-svn.el
+++ b/magit-svn.el
@@ -334,7 +334,7 @@ in `magit-svn-external-directories' and runs
 
 ;;; magit-svn.el ends soon
 
-(define-obsolete-function-alias 'turn-on-magit-svn 'magit-svn-mode)
+(define-obsolete-function-alias 'turn-on-magit-svn 'magit-svn-mode "Sep 3, 2014")
 
 (provide 'magit-svn)
 ;; Local Variables:


### PR DESCRIPTION
On the current master branch of emacs, the `when` parameter has been made mandatory for `define-obsolete-function-alias`. Set to Sep 3, 2014 when the line was introduced.

Excerpt from NEWS:
** The 'when' argument of make-obsolete and related functions is mandatory.
     The use of those functions without a 'when' argument was marked
     obsolete back in Emacs-23.1.  The affected functions are:
     make-obsolete, define-obsolete-function-alias, make-obsolete-variable,
     define-obsolete-variable-alias.